### PR TITLE
이미지 파일 업로드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 ### VS Code ###
 .vscode/
 
+### DS Store ###
+**/.DS_Store
+

--- a/src/main/java/com/fc/mini3server/domain/User.java
+++ b/src/main/java/com/fc/mini3server/domain/User.java
@@ -57,8 +57,6 @@ public class User {
 
     private int duty;
 
-    @Lob
-    @Basic(fetch = FetchType.LAZY)
     private String profileImageUrl;
 
     private LocalDate hiredDate;

--- a/src/main/java/com/fc/mini3server/dto/UserRequestDTO.java
+++ b/src/main/java/com/fc/mini3server/dto/UserRequestDTO.java
@@ -113,6 +113,6 @@ public class UserRequestDTO {
         private String name;
         private Long deptId;
         private String phone;
-        private String profileImageUrl;
+        private String image;
     }
 }

--- a/src/main/java/com/fc/mini3server/service/UserService.java
+++ b/src/main/java/com/fc/mini3server/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
 
-    private static final String FILE_DIR = "./images/";
+    private static final String FILE_DIR = "http://fastcampus-mini-project-env.eba-khrscmx7.ap-northeast-2.elasticbeanstalk.com/images/";
     private static final int MAX_FILE_SIZE = 1024 * 1024;
 
     public void registerNewUser(UserRequestDTO.registerDTO registerDTO) {
@@ -184,7 +184,7 @@ public class UserService {
     private String initiateFileName() {
         LocalDateTime currentTime = LocalDateTime.now();
         String timeStamp = currentTime.format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
-        return "uploadedFile_" + timeStamp;
+        return timeStamp;
     }
 
     public User findById(Long id) {


### PR DESCRIPTION
# 프론트 분들 꼭 읽어주세요

## PR 요약
* 이미지 파일 디코딩 구현
* 이미지 파일 서버 내 저장 구현

## 프론트 공유사항
* 프로필 이미지 파일 업로드는 마이페이지 수정 API를 호출할 때 작동합니다.
* RequestDTO 필드 변경 : profileImageUrl 필드를 image 필드로 변경했습니다. 인코딩된 string value를 여기에 넣으셔야 합니다.
* img src 경로 : "http://fastcampus-mini-project-env.eba-khrscmx7.ap-northeast-2.elasticbeanstalk.com/images/{파일이름}"
* src의 경로의 "파일이름"은 Timestamp를 통해 구현했습니다. "yyyyMMdd_HHmmss" 데이터로 들어가게 될 것입니다.
* 이미지 파일의 경우에는 포스트맨 만으로는 확인하기에 한계가 있어서, 직접 src로 이미지를 불러올 수 있는지 확인이 필요합니다.