### PR TITLE
당직 변경 신청 구현 및 리팩토링

### DIFF
--- a/src/main/java/com/fc/mini3server/_core/handler/Message.java
+++ b/src/main/java/com/fc/mini3server/_core/handler/Message.java
@@ -7,6 +7,7 @@ public interface Message {
     String METHOD_ARGUMENT_TYPE_MISMATCH = "유효하지 않은 파라미터입니다.";
     String NO_USER_DUTY_LEFT = "남은 당직 횟수가 없습니다.";
     String ALREADY_EXISTS_ON_THAT_DATE = "해당 날짜에 이미 당직이 등록 되어있습니다.";
+    String INVALID_SCHEDULE_CATEGORY_NOT_DUTY = "당직 스케줄만 삭제 가능합니다.";
     String INVALID_REGISTER_FORMAT = "요청 형식이 잘못 되었습니다. 올바른 직급, 병원, 또는 부서 번호를 입력 하였는지 확인하십시오.";
     String INVALID_USER_NOT_APPROVED = "인증되지 않은 사용자 입니다.";
     String INVALID_NOT_VALID_TOKEN = "올바른 토큰이 아닙니다.";

--- a/src/main/java/com/fc/mini3server/_core/handler/Message.java
+++ b/src/main/java/com/fc/mini3server/_core/handler/Message.java
@@ -7,6 +7,8 @@ public interface Message {
     String METHOD_ARGUMENT_TYPE_MISMATCH = "유효하지 않은 파라미터입니다.";
     String NO_USER_DUTY_LEFT = "남은 당직 횟수가 없습니다.";
     String ALREADY_EXISTS_ON_THAT_DATE = "해당 날짜에 이미 당직이 등록 되어있습니다.";
+    String NO_DUTY_SCHEDULE_ON_DATE = "바꾸려는 날짜에 당직이 없습니다.";
+    String INVALID_SCHEDULE_EVALUATION = "미처리 된 건만 승인 가능합니다.";
     String INVALID_SCHEDULE_CATEGORY_NOT_DUTY = "당직 스케줄만 삭제 가능합니다.";
     String INVALID_REGISTER_FORMAT = "요청 형식이 잘못 되었습니다. 올바른 직급, 병원, 또는 부서 번호를 입력 하였는지 확인하십시오.";
     String INVALID_USER_NOT_APPROVED = "인증되지 않은 사용자 입니다.";

--- a/src/main/java/com/fc/mini3server/_core/handler/Message.java
+++ b/src/main/java/com/fc/mini3server/_core/handler/Message.java
@@ -7,6 +7,7 @@ public interface Message {
     String METHOD_ARGUMENT_TYPE_MISMATCH = "유효하지 않은 파라미터입니다.";
     String NO_USER_DUTY_LEFT = "남은 당직 횟수가 없습니다.";
     String ALREADY_EXISTS_ON_THAT_DATE = "해당 날짜에 이미 당직이 등록 되어있습니다.";
+    String ALREADY_EXISTS_CHANGE_DUTY_REQUEST = "이미 신청 중인 변경 건이 있습니다.";
     String NO_DUTY_SCHEDULE_ON_DATE = "바꾸려는 날짜에 당직이 없습니다.";
     String INVALID_SCHEDULE_EVALUATION = "미처리 된 건만 승인 가능합니다.";
     String INVALID_SCHEDULE_CATEGORY_NOT_DUTY = "당직 스케줄만 삭제 가능합니다.";

--- a/src/main/java/com/fc/mini3server/_core/handler/Message.java
+++ b/src/main/java/com/fc/mini3server/_core/handler/Message.java
@@ -6,6 +6,7 @@ public interface Message {
     String INVALID_USER_STATUS_APPROVED = "재직 중인 계정만 변경 가능합니다.";
     String METHOD_ARGUMENT_TYPE_MISMATCH = "유효하지 않은 파라미터입니다.";
     String NO_USER_DUTY_LEFT = "남은 당직 횟수가 없습니다.";
+    String ALREADY_EXISTS_ON_THAT_DATE = "해당 날짜에 이미 당직이 등록 되어있습니다.";
     String INVALID_REGISTER_FORMAT = "요청 형식이 잘못 되었습니다. 올바른 직급, 병원, 또는 부서 번호를 입력 하였는지 확인하십시오.";
     String INVALID_USER_NOT_APPROVED = "인증되지 않은 사용자 입니다.";
     String INVALID_NOT_VALID_TOKEN = "올바른 토큰이 아닙니다.";

--- a/src/main/java/com/fc/mini3server/_core/utils/DBInit.java
+++ b/src/main/java/com/fc/mini3server/_core/utils/DBInit.java
@@ -534,26 +534,36 @@ public class DBInit {
                     .endDate(LocalDate.of(2023, 8, 6))
                     .evaluation(EvaluationEnum.APPROVED)
                     .build();
-            Schedule schedule25 = Schedule.builder()
-                    .user(user8)
+
+            Schedule schedule27 = Schedule.builder()
+                    .user(user1)
                     .hospital(hospital1)
                     .category(CategoryEnum.DUTY)
-                    .startDate(LocalDate.of(2023, 8, 7))
-                    .endDate(LocalDate.of(2023, 8, 7))
-                    .evaluation(EvaluationEnum.STANDBY)
+                    .startDate(LocalDate.of(2023, 8, 9))
+                    .endDate(LocalDate.of(2023, 8, 9))
+                    .evaluation(EvaluationEnum.APPROVED)
                     .build();
-            Schedule schedule26 = Schedule.builder()
-                    .user(user9)
+            Schedule schedule28 = Schedule.builder()
+                    .user(user2)
                     .hospital(hospital1)
                     .category(CategoryEnum.DUTY)
-                    .startDate(LocalDate.of(2023, 8, 8))
-                    .endDate(LocalDate.of(2023, 8, 8))
+                    .startDate(LocalDate.of(2023, 8, 10))
+                    .endDate(LocalDate.of(2023, 8, 10))
+                    .evaluation(EvaluationEnum.APPROVED)
+                    .build();
+            Schedule schedule29 = Schedule.builder()
+                    .user(user1)
+                    .hospital(hospital1)
+                    .category(CategoryEnum.DUTY)
+                    .startDate(LocalDate.of(2023, 8, 9))
+                    .endDate(LocalDate.of(2023, 8, 10))
                     .evaluation(EvaluationEnum.STANDBY)
                     .build();
 
             scheduleRepository.saveAll(Arrays.asList(schedule1, schedule2, schedule3, schedule4, schedule5,
                     schedule6, schedule7, schedule8,
-                    schedule21, schedule22, schedule23, schedule24, schedule25, schedule26));
+                    schedule21, schedule22, schedule23, schedule24,
+                    schedule27, schedule28, schedule29));
         };
     }
 }

--- a/src/main/java/com/fc/mini3server/controller/AdminController.java
+++ b/src/main/java/com/fc/mini3server/controller/AdminController.java
@@ -73,7 +73,7 @@ public class AdminController {
     @GetMapping("/annual")
     public ResponseEntity<?> findAnnualList(@PageableDefault(size = 10)
             @SortDefault.SortDefaults({
-                    @SortDefault(sort = "createdAt", direction = Sort.Direction.ASC),
+                    @SortDefault(sort = "updatedAt", direction = Sort.Direction.ASC),
                     @SortDefault(sort = "id", direction = Sort.Direction.ASC)
             }) Pageable pageable){
         final Page<Schedule> scheduleList = adminService.findAnnualList(pageable);
@@ -87,7 +87,7 @@ public class AdminController {
     @GetMapping("/duty")
     public ResponseEntity<?> findDutyList(@PageableDefault(size = 10)
               @SortDefault.SortDefaults({
-                      @SortDefault(sort = "createdAt", direction = Sort.Direction.ASC),
+                      @SortDefault(sort = "updatedAt", direction = Sort.Direction.ASC),
                       @SortDefault(sort = "id", direction = Sort.Direction.ASC)
               }) Pageable pageable){
         final Page<Schedule> scheduleList = adminService.findDutyList(pageable);

--- a/src/main/java/com/fc/mini3server/controller/AdminController.java
+++ b/src/main/java/com/fc/mini3server/controller/AdminController.java
@@ -110,11 +110,17 @@ public class AdminController {
         return ResponseEntity.ok(ApiUtils.success(UserListByHospitalIdDTO.listOf(userList)));
     }
 
-
     @Operation(summary = "당직 추가", description = "선택한 당직인원을 실제 당직인원으로 추가한다.")
-    @PostMapping("/{id}/createDuty")
-    public ResponseEntity<?> createDuty(@PathVariable Long id, @RequestBody createDutyAdminDTO requestDTO){
-        adminService.createDuty(id, requestDTO);
+    @PostMapping("/{userId}/createDuty")
+    public ResponseEntity<?> createDuty(@PathVariable Long userId, @RequestBody createDutyAdminDTO requestDTO){
+        adminService.createDuty(userId, requestDTO);
+        return ResponseEntity.ok(ApiUtils.success(null));
+    }
+
+    @Operation(summary = "당직 삭제", description = "요청한 날짜에 당직을 삭제한다.")
+    @PostMapping("/{scheduleId}/deleteDuty")
+    public ResponseEntity<?> deleteDuty(@PathVariable Long scheduleId){
+        adminService.deleteDuty(scheduleId);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 }

--- a/src/main/java/com/fc/mini3server/controller/AdminController.java
+++ b/src/main/java/com/fc/mini3server/controller/AdminController.java
@@ -97,9 +97,9 @@ public class AdminController {
     }
 
     @Operation(summary = "스케줄 승인/반려", description = "STANDBY -> APPROVED, STANDBY -> REJECTED")
-    @PostMapping("/{id}/evaluation")
-    public ResponseEntity<?> editEvaluation(@PathVariable Long id, @RequestBody editEvaluationDTO requestDTO){
-        adminService.updateScheduleEvaluation(id, requestDTO);
+    @PostMapping("/{scheduleId}/evaluation")
+    public ResponseEntity<?> editEvaluation(@PathVariable Long scheduleId, @RequestBody editEvaluationDTO requestDTO){
+        adminService.updateScheduleEvaluation(scheduleId, requestDTO);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 

--- a/src/main/java/com/fc/mini3server/controller/ScheduleController.java
+++ b/src/main/java/com/fc/mini3server/controller/ScheduleController.java
@@ -8,7 +8,6 @@ import com.fc.mini3server.domain.CategoryEnum;
 import com.fc.mini3server.service.ScheduleService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/fc/mini3server/controller/ScheduleController.java
+++ b/src/main/java/com/fc/mini3server/controller/ScheduleController.java
@@ -33,6 +33,7 @@ public class ScheduleController {
         return ResponseEntity.ok(ApiUtils.success(scheduleService.getApprovedSchedule()));
     }
 
+    @Operation(summary = "날짜별 휴가/당직 인원 조회", description = "날짜별로 클릭 시 데이터 출력")
     @GetMapping("/date")
     public ResponseEntity<?> getScheduleByDate(@RequestParam("chooseDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate chooseDate,
                                                  @RequestParam("category") CategoryEnum category){
@@ -51,6 +52,7 @@ public class ScheduleController {
         return ResponseEntity.ok(ApiUtils.error(Message.METHOD_ARGUMENT_TYPE_MISMATCH, HttpStatus.BAD_REQUEST));
     }
 
+    @Operation(summary = "요청 내역 확인")
     @GetMapping("/{id}")
     public ResponseEntity<?> getScheduleRequestList(@PathVariable Long id){
         List<Schedule> scheduleList = scheduleService.findAllRequestSchedule(id);

--- a/src/main/java/com/fc/mini3server/controller/ScheduleController.java
+++ b/src/main/java/com/fc/mini3server/controller/ScheduleController.java
@@ -3,9 +3,9 @@ package com.fc.mini3server.controller;
 import com.fc.mini3server._core.handler.Message;
 import com.fc.mini3server._core.utils.ApiUtils;
 import com.fc.mini3server.domain.Schedule;
-import com.fc.mini3server.dto.ScheduleRequestDTO;
 import com.fc.mini3server.domain.CategoryEnum;
 import com.fc.mini3server.service.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -58,26 +58,21 @@ public class ScheduleController {
     }
 
     @PostMapping("annual/{id}/update")
-    public ResponseEntity<?> updateAnnualSchedule(@PathVariable Long id, @RequestBody ScheduleRequestDTO.createAnnualDTO updateDTO) {
+    public ResponseEntity<?> updateAnnualSchedule(@PathVariable Long id, @RequestBody createAnnualDTO updateDTO) {
         scheduleService.updateAnnual(id, updateDTO);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 
-    @PostMapping("duty/{id}/update")
-    public ResponseEntity<?> updateDutySchedule(@PathVariable Long id, @RequestBody ScheduleRequestDTO.createDutyDTO updateDTO) {
-        scheduleService.updateDuty(id, updateDTO);
+    @Operation(summary = "당직 변경 신청", description = "현재 본인의 스케줄에서 변경 요청을 하는 스케줄의 Date를 넣는다.")
+    @PostMapping("duty/{scheduleId}/update")
+    public ResponseEntity<?> changeDutySchedule(@PathVariable Long scheduleId, @RequestBody updateDutyDTO requestDTO) {
+        scheduleService.changeReqDuty(scheduleId, requestDTO);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 
     @PostMapping("/create/annual")
-    public ResponseEntity<ApiUtils.ApiResult<Schedule>> createAnnualSchedule(@RequestBody @Valid ScheduleRequestDTO.createAnnualDTO createAnnualDTO) {
+    public ResponseEntity<ApiUtils.ApiResult<Schedule>> createAnnualSchedule(@RequestBody @Valid createAnnualDTO createAnnualDTO) {
         scheduleService.createAnnualSchedule(createAnnualDTO);
-        return ResponseEntity.ok(ApiUtils.success(null));
-    }
-
-    @PostMapping("/create/duty")
-    public ResponseEntity<ApiUtils.ApiResult<Schedule>> createDutySchedule(@RequestBody @Valid ScheduleRequestDTO.createDutyDTO createDutyDTO) {
-        scheduleService.createDutySchedule(createDutyDTO);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 

--- a/src/main/java/com/fc/mini3server/dto/AdminResponseDTO.java
+++ b/src/main/java/com/fc/mini3server/dto/AdminResponseDTO.java
@@ -66,13 +66,14 @@ public class AdminResponseDTO {
         private CategoryEnum category;
         private LevelEnum level;
         private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
         private LocalDate startDate;
         private LocalDate endDate;
         private EvaluationEnum evaluation;
 
         public static AdminAnnualListDTO of(Schedule schedule) {
             return new AdminAnnualListDTO(schedule.getId(), schedule.getUser().getName(),
-                    schedule.getCategory(), schedule.getUser().getLevel(), schedule.getCreatedAt(),
+                    schedule.getCategory(), schedule.getUser().getLevel(), schedule.getCreatedAt(), schedule.getUpdatedAt(),
                     schedule.getStartDate(), schedule.getEndDate(), schedule.getEvaluation());
         }
 
@@ -91,13 +92,14 @@ public class AdminResponseDTO {
         private CategoryEnum category;
         private LevelEnum level;
         private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
         private LocalDate startDate;
         private LocalDate updateDate;
         private EvaluationEnum evaluation;
 
         public static DutyListDTO of(Schedule schedule) {
             return new DutyListDTO(schedule.getId(), schedule.getUser().getName(), schedule.getHospital().getName(),
-                    schedule.getCategory(), schedule.getUser().getLevel(), schedule.getCreatedAt(),
+                    schedule.getCategory(), schedule.getUser().getLevel(), schedule.getCreatedAt(), schedule.getUpdatedAt(),
                     schedule.getStartDate(), schedule.getEndDate(), schedule.getEvaluation());
         }
 

--- a/src/main/java/com/fc/mini3server/dto/AdminResponseDTO.java
+++ b/src/main/java/com/fc/mini3server/dto/AdminResponseDTO.java
@@ -87,16 +87,18 @@ public class AdminResponseDTO {
     public static class DutyListDTO {
         private Long scheduleId;
         private String username;
+        private String hospitalName;
         private CategoryEnum category;
         private LevelEnum level;
         private LocalDateTime createdAt;
         private LocalDate startDate;
+        private LocalDate updateDate;
         private EvaluationEnum evaluation;
 
         public static DutyListDTO of(Schedule schedule) {
-            return new DutyListDTO(schedule.getId(), schedule.getUser().getName(),
+            return new DutyListDTO(schedule.getId(), schedule.getUser().getName(), schedule.getHospital().getName(),
                     schedule.getCategory(), schedule.getUser().getLevel(), schedule.getCreatedAt(),
-                    schedule.getStartDate(), schedule.getEvaluation());
+                    schedule.getStartDate(), schedule.getEndDate(), schedule.getEvaluation());
         }
 
         public static List<DutyListDTO> listOf(List<Schedule> scheduleList){

--- a/src/main/java/com/fc/mini3server/dto/ScheduleRequestDTO.java
+++ b/src/main/java/com/fc/mini3server/dto/ScheduleRequestDTO.java
@@ -25,12 +25,12 @@ public class ScheduleRequestDTO {
 
     }
 
-    @Data
-    public static class createDutyDTO {
-
-        @NotNull
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class updateDutyDTO {
         private LocalDate startDate;
-        private User user;
+        private LocalDate updateDate;
     }
 
     @NoArgsConstructor

--- a/src/main/java/com/fc/mini3server/repository/ScheduleRepository.java
+++ b/src/main/java/com/fc/mini3server/repository/ScheduleRepository.java
@@ -21,6 +21,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByEvaluationAndUserHospitalId(EvaluationEnum evaluation, Long hospitalId);
     List<Schedule> findByHospitalIdAndEvaluationAndCategoryAndStartDateIsLessThanEqualAndEndDateIsGreaterThanEqual(Long hospitalId, EvaluationEnum evaluation, CategoryEnum category, LocalDate startDate, LocalDate endDate);
     Optional<Schedule> findByHospitalIdAndEvaluationAndCategoryAndStartDate(Long HospitalId, EvaluationEnum evaluation, CategoryEnum category, LocalDate startDate);
+    Optional<Schedule> findByHospitalIdAndEvaluationAndCategoryAndStartDateAndEndDate(Long hospitalId, EvaluationEnum evaluationEnum, CategoryEnum category, LocalDate chooseDate, LocalDate chooseDate1);
     List<Schedule> findByUserId(Long userId);
 
     @Modifying

--- a/src/main/java/com/fc/mini3server/repository/ScheduleRepository.java
+++ b/src/main/java/com/fc/mini3server/repository/ScheduleRepository.java
@@ -26,4 +26,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Modifying
     @Query("UPDATE schedule_tb s SET s.evaluation = 'CANCELED' WHERE s.id = :scheduleId")
     void updateEvaluationToCanceled(@Param("scheduleId") Long scheduleId);
+
+    boolean existsScheduleByStartDateAndCategoryAndEvaluation(LocalDate chooseDate, CategoryEnum category, EvaluationEnum evaluation);
 }

--- a/src/main/java/com/fc/mini3server/repository/ScheduleRepository.java
+++ b/src/main/java/com/fc/mini3server/repository/ScheduleRepository.java
@@ -27,5 +27,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("UPDATE schedule_tb s SET s.evaluation = 'CANCELED' WHERE s.id = :scheduleId")
     void updateEvaluationToCanceled(@Param("scheduleId") Long scheduleId);
 
-    boolean existsScheduleByStartDateAndCategoryAndEvaluation(LocalDate chooseDate, CategoryEnum category, EvaluationEnum evaluation);
+    boolean existsScheduleByHospitalIdAndStartDateAndCategoryAndEvaluation(Long id, LocalDate chooseDate, CategoryEnum categoryEnum, EvaluationEnum evaluationEnum);
+
+    boolean existsByHospitalIdAndEvaluationAndCategoryAndEndDate(Long id, EvaluationEnum evaluationEnum, CategoryEnum categoryEnum, LocalDate updateDate);
+
+
 }

--- a/src/main/java/com/fc/mini3server/service/AdminService.java
+++ b/src/main/java/com/fc/mini3server/service/AdminService.java
@@ -90,8 +90,8 @@ public class AdminService {
                 () -> new Exception400(String.valueOf(user.getHospital().getId()), Message.HOSPITAL_NOT_FOUND)
         );
 
-        if(scheduleRepository.existsScheduleByStartDateAndCategoryAndEvaluation(
-                requestDTO.getChooseDate(), CategoryEnum.DUTY, EvaluationEnum.APPROVED))
+        if(scheduleRepository.existsScheduleByHospitalIdAndStartDateAndCategoryAndEvaluation(
+                user.getHospital().getId(), requestDTO.getChooseDate(), CategoryEnum.DUTY, EvaluationEnum.APPROVED))
             throw new Exception400(Message.ALREADY_EXISTS_ON_THAT_DATE);
 
         Schedule schedule = Schedule.builder()

--- a/src/main/java/com/fc/mini3server/service/AdminService.java
+++ b/src/main/java/com/fc/mini3server/service/AdminService.java
@@ -89,6 +89,10 @@ public class AdminService {
                 () -> new Exception400(String.valueOf(user.getHospital().getId()), Message.HOSPITAL_NOT_FOUND)
         );
 
+        if(scheduleRepository.existsScheduleByStartDateAndCategoryAndEvaluation(
+                requestDTO.getChooseDate(), CategoryEnum.DUTY, EvaluationEnum.APPROVED))
+            throw new Exception400(Message.ALREADY_EXISTS_ON_THAT_DATE);
+
         Schedule schedule = Schedule.builder()
                 .user(user)
                 .hospital(hospital)

--- a/src/main/java/com/fc/mini3server/service/AdminService.java
+++ b/src/main/java/com/fc/mini3server/service/AdminService.java
@@ -122,4 +122,16 @@ public class AdminService {
 
         schedule.updateEvaluation(requestDTO.getEvaluation());
     }
+
+    @Transactional
+    public void deleteDuty(Long id) {
+        Schedule schedule = scheduleRepository.findById(id).orElseThrow(
+                () -> new Exception400(String.valueOf(id), INVALID_ID_PARAMETER)
+        );
+
+        if (!schedule.getCategory().equals(CategoryEnum.DUTY))
+            throw new Exception400(Message.INVALID_SCHEDULE_CATEGORY_NOT_DUTY);
+
+        scheduleRepository.delete(schedule);
+    }
 }

--- a/src/main/java/com/fc/mini3server/service/ScheduleService.java
+++ b/src/main/java/com/fc/mini3server/service/ScheduleService.java
@@ -144,8 +144,8 @@ public class ScheduleService {
     public Schedule findByDutyScheduleByDate(getScheduleReqDTO requestDTO){
         Long hospitalId = userService.getUser().getHospital().getId();
 
-        return scheduleRepository.findByHospitalIdAndEvaluationAndCategoryAndStartDate(
-                hospitalId, EvaluationEnum.APPROVED, requestDTO.getCategory(), requestDTO.getChooseDate()
+        return scheduleRepository.findByHospitalIdAndEvaluationAndCategoryAndStartDateAndEndDate(
+                hospitalId, EvaluationEnum.APPROVED, requestDTO.getCategory(), requestDTO.getChooseDate(), requestDTO.getChooseDate()
         ).orElseThrow(
                 () -> new Exception404("금일 당직 인원이 없습니다.")
         );


### PR DESCRIPTION
- [x] 스케줄 승인/반려 기능 리팩토링
- [x] 캘린더에서 당직등록 하는걸 당직 변경등록으로 변경하고 어드민에서 승인
- [x] 당직 인원 조회 시 startDate 와 endDate가 같은 것만 출력
- [x] 어드민 당직 정렬 리팩토링 createdAt -> updatedAt 기준 변경

issue : schedule 테이블에 변경 신청용 데이터와 실제 해당 일자에 당직인 사람의 `Evaluation` 값이 동일하여 당직 인원 조회 조건에 startDate, endDate가 같은 경우도 추가